### PR TITLE
feature/KAS-1425 model refactor: Activity

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -16,7 +16,7 @@ const mandateeIsCompetentOnFutureAgendaItem = async (endDateOfMandee, mandateeId
   ?procedurestap besluitvorming:heeftBevoegde ?mandataris .
   ?mandataris a mandaat:Mandataris .
   ?mandataris mu:uuid ${sparqlEscapeString(mandateeId)} .
-  ?procedurestap besluitvorming:isGeagendeerdVia ?agendaPunt .
+  ?procedurestap ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendapunt .
   ?agendaPunt a besluit:Agendapunt .
   ?agenda dct:hasPart ?agendaPunt.
   ?agenda a besluitvorming:Agenda .


### PR DESCRIPTION
# :mag:  KAS-1425: Model refactor: activity model gebruiken
De refactor verlegt de relatie tussen procedurstap en agendaitem naar een tussenobject: de agendering-activiteit
Bij de refactor hoort ook een deel opkuis van: postponed, procedurestapfases en fasecodes.

## ✏️  What has changed

### repository/index.js:
Relatie tussen subcase en agendaitem ligt nu via agendering-activiteit 