### PR TITLE
KAS-1422 rename relation

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -9,11 +9,11 @@ const mandateeIsCompetentOnFutureAgendaItem = async (endDateOfMandee, mandateeId
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
   PREFIX dct: <http://purl.org/dc/terms/>
-
+  PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
 
   ASK WHERE {
   ?procedurestap a dbpedia:UnitOfWork .
-  ?procedurestap besluitvorming:heeftBevoegde ?mandataris .
+  ?procedurestap ext:heeftBevoegde ?mandataris .
   ?mandataris a mandaat:Mandataris .
   ?mandataris mu:uuid ${sparqlEscapeString(mandateeId)} .
   ?procedurestap ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendapunt .


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- besluitvorming:heeftBevoegde => ext:heeftBevoegde